### PR TITLE
[REN-1] Fix CMake build error on Windows 10 by exporting zlibstatic alongside Ptex_static

### DIFF
--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -119,6 +119,17 @@ set_property (TARGET Ptex_static ptxinfo halftest ftest rtest wtest PROPERTY FOL
 
 set (PTEX_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/ptex/src/ptex PARENT_SCOPE)
 
+# Only do this if both targets actually exist
+if (TARGET Ptex_static AND TARGET zlibstatic)
+  install(
+    TARGETS zlibstatic
+    EXPORT Ptex             # Same export set name as used by Ptex
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+  )
+endif()
+
 ###########################################################################
 # double-conversion
 


### PR DESCRIPTION
* Adds a post-configuration step that explicitly installs `zlibstatic` into the `Ptex` export set.
* Prevents "target not in any export set" errors during the installation stage.
* Leaves the existing Ptex submodule files unmodified, preserving upstream compatibility.
* Verified on Windows 10 with Visual Studio 2022.